### PR TITLE
server: fix conn.shutdown() hanging when called twice

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -122,8 +122,16 @@ type conn struct {
 
 func (conn *conn) shutdown() {
 	conn.cancel()
-	conn.wdone <- struct{}{}
-	conn.rdone <- struct{}{}
+	// Use non-blocking sends since shutdown may be called multiple
+	// times (from runReciever exit and from Server.Shutdown).
+	select {
+	case conn.wdone <- struct{}{}:
+	default:
+	}
+	select {
+	case conn.rdone <- struct{}{}:
+	default:
+	}
 	conn.t.Close()
 }
 


### PR DESCRIPTION
conn.shutdown() sends to the wdone and rdone buffered channels
(capacity 1) to signal runSender and runReciever to stop. However
runReciever calls conn.shutdown() itself on exit, and Server.Shutdown
also calls conn.shutdown() on every active connection. When shutdown
is called twice, the second send blocks forever because the channel
is already full.

Fix by using non-blocking sends so that duplicate shutdown calls are
harmless.
