### PR TITLE
vfs: fix build on 32-bit Linux architectures

### DIFF
--- a/vfs/fileinfo_linux.go
+++ b/vfs/fileinfo_linux.go
@@ -13,12 +13,12 @@ func CompatStat(stat os.FileInfo) (Stat, bool) {
 	}
 
 	s := Stat{
-		Ino:     sysStat.Ino,
-		Blocks:  sysStat.Blocks,
+		Ino:     uint64(sysStat.Ino),
+		Blocks:  int64(sysStat.Blocks),
 		BlkSize: int32(sysStat.Blksize),
-		Atime:   time.Unix(sysStat.Atim.Sec, sysStat.Atim.Nsec),
-		Mtime:   time.Unix(sysStat.Mtim.Sec, sysStat.Mtim.Nsec),
-		Ctime:   time.Unix(sysStat.Ctim.Sec, sysStat.Ctim.Nsec),
+		Atime:   time.Unix(int64(sysStat.Atim.Sec), int64(sysStat.Atim.Nsec)),
+		Mtime:   time.Unix(int64(sysStat.Mtim.Sec), int64(sysStat.Mtim.Nsec)),
+		Ctime:   time.Unix(int64(sysStat.Ctim.Sec), int64(sysStat.Ctim.Nsec)),
 		Btime:   time.Unix(0, 0),
 	}
 


### PR DESCRIPTION
Add explicit int64/uint64 casts to syscall.Stat_t fields which are
int32/uint32 on 32-bit platforms but int64/uint64 on 64-bit.
